### PR TITLE
Update copywrite info in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, Bradley R Taylor
+Copyright (c) 2019, Broad Institute, Inc., Verily Life Sciences LLC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Copyright now properly attributed to Broad, Verily